### PR TITLE
Expose Credential and VdcCollection over FFI.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2061,6 +2061,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+
+[[package]]
 name = "futures-util"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3182,7 +3188,7 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69ec2f49393a1347a2d95ebcb248ff75d0d47235919b678036c010a8cd927375"
 dependencies = [
- "proc-macro-crate",
+ "proc-macro-crate 1.1.3",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -3385,6 +3391,7 @@ dependencies = [
  "p256",
  "pem-rfc7468 0.7.0",
  "reqwest 0.11.27",
+ "rstest",
  "serde",
  "serde_cbor",
  "serde_json",
@@ -3452,7 +3459,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d6d4752e6230d8ef7adf7bd5d8c4b1f6561c1014c5ba9a37445ccefe18aa1db"
 dependencies = [
- "proc-macro-crate",
+ "proc-macro-crate 1.1.3",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -4082,6 +4089,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-crate"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
+dependencies = [
+ "toml_edit",
+]
+
+[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4293,6 +4309,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
+name = "relative-path"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
+
+[[package]]
 name = "replace_with"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4479,6 +4501,36 @@ dependencies = [
  "spki 0.7.3",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rstest"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b423f0e62bdd61734b67cd21ff50871dfaeb9cc74f869dcd6af974fbcb19936"
+dependencies = [
+ "futures",
+ "futures-timer",
+ "rstest_macros",
+ "rustc_version",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5e1711e7d14f74b12a58411c542185ef7fb7f2e7f8ee6e2940a883628522b42"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro-crate 3.2.0",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version",
+ "syn 2.0.72",
+ "unicode-ident",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,9 +89,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
- "getrandom",
  "once_cell",
- "serde",
  "version_check",
  "zerocopy 0.7.35",
 ]
@@ -576,21 +574,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bit-set"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
-dependencies = [
- "bit-vec",
-]
-
-[[package]]
-name = "bit-vec"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -778,12 +761,6 @@ name = "bumpalo"
 version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
-
-[[package]]
-name = "bytecount"
-version = "0.6.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ce89b21cab1437276d2650d57e971f9d548a2d9037cc231abdc0562b97498ce"
 
 [[package]]
 name = "bytemuck"
@@ -1730,7 +1707,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
- "base64ct",
  "crypto-bigint 0.5.5",
  "digest 0.10.7",
  "ff 0.13.0",
@@ -1741,7 +1717,6 @@ dependencies = [
  "pkcs8 0.10.2",
  "rand_core",
  "sec1",
- "serde_json",
  "serdect",
  "subtle",
  "zeroize",
@@ -1869,17 +1844,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fancy-regex"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "531e46835a22af56d1e3b66f04844bed63158bc094a628bec1d321d9b4c44bf2"
-dependencies = [
- "bit-set",
- "regex-automata",
- "regex-syntax",
-]
-
-[[package]]
 name = "fastrand"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1974,16 +1938,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
-]
-
-[[package]]
-name = "fraction"
-version = "0.15.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f158e3ff0a1b334408dc9fb811cd99b446986f4d8b741bb08f9df1604085ae7"
-dependencies = [
- "lazy_static",
- "num",
 ]
 
 [[package]]
@@ -2738,15 +2692,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
-name = "iso8601"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "924e5d73ea28f59011fec52a0d12185d496a9b075d360657aed2a5707f701153"
-dependencies = [
- "nom",
-]
-
-[[package]]
 name = "isomdl"
 version = "0.1.0"
 source = "git+https://github.com/spruceid/isomdl?rev=1f4f762#1f4f762841b5f7744288966f048726107f2b4dbe"
@@ -3026,7 +2971,6 @@ dependencies = [
  "lexical",
  "ryu-js",
  "serde",
- "serde_json",
  "smallvec",
 ]
 
@@ -3056,51 +3000,9 @@ dependencies = [
  "locspan-derive",
  "ryu-js",
  "serde",
- "serde_json",
  "smallstr",
  "smallvec",
  "utf8-decode",
-]
-
-[[package]]
-name = "jsonpath_lib"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaa63191d68230cccb81c5aa23abd53ed64d83337cacbb25a7b8c7979523774f"
-dependencies = [
- "log",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "jsonschema"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5f037c58cadb17e8591b620b523cc6a7ab2b91b6ce3121f8eb4171f8d80115c"
-dependencies = [
- "ahash 0.8.11",
- "anyhow",
- "base64 0.22.1",
- "bytecount",
- "clap 4.5.13",
- "fancy-regex",
- "fraction",
- "getrandom",
- "iso8601",
- "itoa",
- "memchr",
- "num-cmp",
- "once_cell",
- "parking_lot",
- "percent-encoding",
- "regex",
- "reqwest 0.12.5",
- "serde",
- "serde_json",
- "time",
- "url",
- "uuid",
 ]
 
 [[package]]
@@ -3480,7 +3382,6 @@ dependencies = [
  "hex",
  "isomdl 0.1.0 (git+https://github.com/spruceid/isomdl?rev=1f4f762)",
  "oid4vci",
- "oid4vp",
  "p256",
  "pem-rfc7468 0.7.0",
  "reqwest 0.11.27",
@@ -3587,20 +3488,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
-dependencies = [
- "num-bigint",
- "num-complex",
- "num-integer",
- "num-iter",
- "num-rational",
- "num-traits",
-]
-
-[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3625,21 +3512,6 @@ dependencies = [
  "rand",
  "smallvec",
  "zeroize",
-]
-
-[[package]]
-name = "num-cmp"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63335b2e2c34fae2fb0aa2cecfd9f0832a1e24b3b32ecec612c3426d46dc8aaa"
-
-[[package]]
-name = "num-complex"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
-dependencies = [
- "num-traits",
 ]
 
 [[package]]
@@ -3752,45 +3624,6 @@ dependencies = [
  "time",
  "tracing",
  "url",
-]
-
-[[package]]
-name = "oid4vp"
-version = "0.1.0"
-source = "git+https://github.com/Ryanmtate/oid4vp-rs?rev=915b922#915b92264d31990fb9797755ebe8ee599b663cac"
-dependencies = [
- "anyhow",
- "async-trait",
- "base64 0.21.7",
- "http 1.1.0",
- "json-syntax",
- "jsonpath_lib",
- "jsonschema",
- "oid4vp-frontend",
- "p256",
- "rand",
- "reqwest 0.12.5",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "ssi-claims",
- "ssi-dids",
- "ssi-jwk 0.2.1",
- "ssi-verification-methods",
- "tokio",
- "tracing",
- "url",
- "uuid",
- "x509-cert 0.2.5",
-]
-
-[[package]]
-name = "oid4vp-frontend"
-version = "0.1.0"
-source = "git+https://github.com/Ryanmtate/oid4vp-rs?rev=915b922#915b92264d31990fb9797755ebe8ee599b663cac"
-dependencies = [
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -4518,7 +4351,6 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "encoding_rs",
- "futures-channel",
  "futures-core",
  "futures-util",
  "h2 0.4.5",
@@ -4969,7 +4801,6 @@ version = "1.0.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ab380d7d9f22ef3f21ad3e6c1ebe8e4fc7a2000ccba2e4d71fc96f15b2cb609"
 dependencies = [
- "indexmap 2.3.0",
  "itoa",
  "memchr",
  "ryu",
@@ -5875,19 +5706,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ssi-tzkey"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09da3f842da7cb58986a90ba10c32db5c51d30bcf5d519b26cbb5665d4e80d4f"
-dependencies = [
- "bs58",
- "ed25519-dalek",
- "ssi-jwk 0.2.1",
- "ssi-jws",
- "thiserror",
-]
-
-[[package]]
 name = "ssi-ucan"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5995,7 +5813,6 @@ dependencies = [
  "ssi-jws",
  "ssi-multicodec",
  "ssi-security",
- "ssi-tzkey",
  "ssi-verification-methods-core",
  "static-iref",
  "thiserror",
@@ -6744,7 +6561,6 @@ dependencies = [
  "atomic",
  "getrandom",
  "serde",
- "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ futures = "0.3"
 hex = "0.4.3"
 isomdl = { git = "https://github.com/spruceid/isomdl", rev = "1f4f762" }
 oid4vci = { git = "https://github.com/spruceid/oid4vci-rs", rev = "020887f" }
-oid4vp = { git = "https://github.com/spruceid/oid4vp-rs" }
 p256 = { version = "0.13.2", features = ["pkcs8"] }
 pem-rfc7468 = "0.7.0"
 reqwest = { version = "0.11", features = ["blocking"] }
@@ -45,7 +44,3 @@ base64 = "0.22.0"
 
 [build-dependencies]
 uniffi = { version = "0.28.1", features = ["build"] }
-
-[patch.'https://github.com/spruceid/oid4vp-rs']
-# TODO: replace this once oid4vp is merged.
-oid4vp = { git = "https://github.com/Ryanmtate/oid4vp-rs", rev = "915b922" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,9 +38,10 @@ uuid = { version = "1.6.1", features = ["v4"] }
 w3c-vc-barcodes = { git = "https://github.com/spruceid/w3c-vc-barcodes", rev = "372ff39" }
 
 [dev-dependencies]
-uniffi = { version = "0.28.1", features = ["bindgen-tests"] }
-tokio = "1.39.2"
 base64 = "0.22.0"
+rstest = "0.22.0"
+tokio = "1.39.2"
+uniffi = { version = "0.28.1", features = ["bindgen-tests"] }
 
 [build-dependencies]
 uniffi = { version = "0.28.1", features = ["build"] }

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,33 +1,16 @@
 use crate::UniffiCustomTypeConverter;
 
-// Re-export Uuid for common use.
-pub use oid4vp::core::credential_format::{ClaimFormatDesignation, CredentialType};
+use serde::{Deserialize, Serialize};
 pub use url::Url;
 pub use uuid::Uuid;
 
-uniffi::custom_type!(CredentialType, String);
-impl UniffiCustomTypeConverter for CredentialType {
-    type Builtin = String;
-    fn into_custom(credential_type: Self::Builtin) -> uniffi::Result<Self> {
-        Ok(CredentialType::from(credential_type.as_str()))
-    }
-    fn from_custom(credential_type: Self) -> Self::Builtin {
-        credential_type.into()
-    }
-}
+uniffi::custom_newtype!(CredentialType, String);
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+pub struct CredentialType(pub String);
 
-uniffi::custom_type!(ClaimFormatDesignation, String);
-impl UniffiCustomTypeConverter for ClaimFormatDesignation {
-    type Builtin = String;
-    fn into_custom(claim_format_designation: Self::Builtin) -> uniffi::Result<Self> {
-        Ok(ClaimFormatDesignation::from(
-            claim_format_designation.as_str(),
-        ))
-    }
-    fn from_custom(claim_format_designation: Self) -> Self::Builtin {
-        claim_format_designation.into()
-    }
-}
+uniffi::custom_newtype!(KeyAlias, String);
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+pub struct KeyAlias(pub String);
 
 uniffi::custom_type!(Uuid, String);
 impl UniffiCustomTypeConverter for Uuid {

--- a/src/credential.rs
+++ b/src/credential.rs
@@ -18,10 +18,45 @@ pub struct Credential {
 
 /// The format of the credential.
 #[derive(uniffi::Enum, PartialEq, Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "snake_case")]
 pub enum CredentialFormat {
     MsoMdoc,
     JwtVcJson,
+    #[serde(rename = "jwt_vc_json-ld")]
     JwtVcJsonLd,
     LdpVc,
+    #[serde(untagged)]
     Other(String), // For ease of expansion.
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[rstest::rstest]
+    #[case::mso_mdoc(r#""mso_mdoc""#, CredentialFormat::MsoMdoc)]
+    #[case::jwt_vc_json(r#""jwt_vc_json""#, CredentialFormat::JwtVcJson)]
+    #[case::jwt_vc_json_ld(r#""jwt_vc_json-ld""#, CredentialFormat::JwtVcJsonLd)]
+    #[case::ldp_vc(r#""ldp_vc""#, CredentialFormat::LdpVc)]
+    #[case::other(r#""something_else""#, CredentialFormat::Other("something_else".into()))]
+    fn credential_format_roundtrips(#[case] expected: String, #[case] value: CredentialFormat) {
+        let serialized = serde_json::to_string(&value).unwrap();
+        assert_eq!(expected, serialized);
+
+        let roundtripped: CredentialFormat = serde_json::from_str(&serialized).unwrap();
+
+        assert_eq!(value, roundtripped);
+    }
+
+    #[test]
+    fn credential_format_roundtrips_other() {
+        let value = CredentialFormat::Other("mso_mdoc".into());
+
+        let serialized = serde_json::to_string(&value).unwrap();
+        assert_eq!(r#""mso_mdoc""#, serialized);
+
+        let roundtripped: CredentialFormat = serde_json::from_str(&serialized).unwrap();
+
+        assert_eq!(CredentialFormat::MsoMdoc, roundtripped);
+    }
 }

--- a/src/credential.rs
+++ b/src/credential.rs
@@ -1,0 +1,27 @@
+use crate::{CredentialType, KeyAlias, Uuid};
+use serde::{Deserialize, Serialize};
+
+/// An individual credential.
+#[derive(Debug, Serialize, Deserialize, uniffi::Record)]
+pub struct Credential {
+    /// The local ID of this credential.
+    pub id: Uuid,
+    /// The format of this credential.
+    pub format: CredentialFormat,
+    /// The type of this credential.
+    pub r#type: CredentialType,
+    /// The raw payload of this credential. The encoding depends on the format.
+    pub payload: Vec<u8>,
+    /// The alias of the key that is authorized to present this credential.
+    pub key_alias: Option<KeyAlias>,
+}
+
+/// The format of the credential.
+#[derive(uniffi::Enum, PartialEq, Debug, Serialize, Deserialize, Clone)]
+pub enum CredentialFormat {
+    MsoMdoc,
+    JwtVcJson,
+    JwtVcJsonLd,
+    LdpVc,
+    Other(String), // For ease of expansion.
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 uniffi::setup_scaffolding!();
 
 pub mod common;
+pub mod credential;
 pub mod local_store;
 pub mod mdl;
 pub mod oid4vci;

--- a/src/oid4vci/mod.rs
+++ b/src/oid4vci/mod.rs
@@ -44,7 +44,7 @@ use ssi::{
     dids::{AnyDidMethod, DIDResolver},
 };
 
-use crate::vdc_collection::CredentialFormat;
+use crate::credential::CredentialFormat;
 
 #[uniffi::export]
 pub async fn oid4vci_initiate_with_offer(

--- a/src/oid4vci/session.rs
+++ b/src/oid4vci/session.rs
@@ -11,7 +11,7 @@ use oid4vci::{
     token,
 };
 
-use crate::vdc_collection::CredentialFormat;
+use crate::credential::CredentialFormat;
 
 use super::Oid4vciError;
 

--- a/src/vdc_collection.rs
+++ b/src/vdc_collection.rs
@@ -98,7 +98,7 @@ impl VdcCollection {
         self.all_entries().map(|list| {
             list.iter()
                 .filter_map(|id| self.get(*id).ok().flatten())
-                .filter(|cred| &cred.r#type == &ctype)
+                .filter(|cred| cred.r#type == ctype)
                 .map(|cred| cred.id)
                 .collect()
         })


### PR DESCRIPTION
This is to enable their use in the Swift and Kotlin libraries.

Also removed the dependency on an unmerged OID4VP branch.