### PR TITLE
increase the jvm memory size to 512mb

### DIFF
--- a/kotlin/gradle.properties
+++ b/kotlin/gradle.properties
@@ -1,3 +1,4 @@
 android.enableJetifier=true
 android.useAndroidX=true
 signing.gnupg.keyName=BD077076A67C38E1
+org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8


### PR DESCRIPTION
See error message below re motivation:

> > Task :mobilesdkrs:buildCargoNdkDebug
>     Building armeabi-v7a (armv7-linux-androideabi)
>    Compiling mobile-sdk-rs v0.1.0 (/Users/rmt/Projects/SpruceId/mobile-sdk-rs)
> 
> The Daemon will expire after the build after running out of JVM Metaspace. The project memory settings are likely not configured or are configured to an insufficient value. The daemon will restart for the next build, which may increase subsequent build times. These settings can be adjusted by setting 'org.gradle.jvmargs' in 'gradle.properties'. The currently configured max heap space is '512 MiB' and the configured max metaspace is '256 MiB'. For more information on how to set these values, visit the user guide at https://docs.gradle.org/8.0/userguide/build_environment.html#configuring_jvm_memory To disable this warning, set 'org.gradle.daemon.performance.disable-logging=true'. Daemon will be stopped at the end of the build after running out of JVM Metaspace