### PR TITLE
Add convenience functions to ParsedCredential

### DIFF
--- a/MobileSdkRs/Sources/MobileSdkRs/mobile_sdk_rs.swift
+++ b/MobileSdkRs/Sources/MobileSdkRs/mobile_sdk_rs.swift
@@ -2723,9 +2723,19 @@ public protocol ParsedCredentialProtocol : AnyObject {
     func asMsoMdoc()  -> Mdoc?
     
     /**
+     * Get the local ID for this credential.
+     */
+    func id()  -> Uuid
+    
+    /**
      * Convert a parsed credential into the generic form for storage.
      */
     func intoGenericForm() throws  -> Credential
+    
+    /**
+     * Get the key alias for this credential.
+     */
+    func keyAlias()  -> KeyAlias?
     
 }
 
@@ -2859,11 +2869,31 @@ open func asMsoMdoc() -> Mdoc? {
 }
     
     /**
+     * Get the local ID for this credential.
+     */
+open func id() -> Uuid {
+    return try!  FfiConverterTypeUuid.lift(try! rustCall() {
+    uniffi_mobile_sdk_rs_fn_method_parsedcredential_id(self.uniffiClonePointer(),$0
+    )
+})
+}
+    
+    /**
      * Convert a parsed credential into the generic form for storage.
      */
 open func intoGenericForm()throws  -> Credential {
     return try  FfiConverterTypeCredential.lift(try rustCallWithError(FfiConverterTypeCredentialEncodingError.lift) {
     uniffi_mobile_sdk_rs_fn_method_parsedcredential_into_generic_form(self.uniffiClonePointer(),$0
+    )
+})
+}
+    
+    /**
+     * Get the key alias for this credential.
+     */
+open func keyAlias() -> KeyAlias? {
+    return try!  FfiConverterOptionTypeKeyAlias.lift(try! rustCall() {
+    uniffi_mobile_sdk_rs_fn_method_parsedcredential_key_alias(self.uniffiClonePointer(),$0
     )
 })
 }
@@ -7966,7 +7996,13 @@ private var initializationResult: InitializationResult = {
     if (uniffi_mobile_sdk_rs_checksum_method_parsedcredential_as_mso_mdoc() != 54804) {
         return InitializationResult.apiChecksumMismatch
     }
+    if (uniffi_mobile_sdk_rs_checksum_method_parsedcredential_id() != 46894) {
+        return InitializationResult.apiChecksumMismatch
+    }
     if (uniffi_mobile_sdk_rs_checksum_method_parsedcredential_into_generic_form() != 30318) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_mobile_sdk_rs_checksum_method_parsedcredential_key_alias() != 52023) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_mobile_sdk_rs_checksum_method_storagemanagerinterface_add() != 39162) {

--- a/src/credential/mod.rs
+++ b/src/credential/mod.rs
@@ -120,6 +120,26 @@ impl ParsedCredential {
         }
     }
 
+    /// Get the local ID for this credential.
+    pub fn id(&self) -> Uuid {
+        match &self.inner {
+            ParsedCredentialInner::MsoMdoc(arc) => arc.id(),
+            ParsedCredentialInner::JwtVcJson(arc) => arc.id(),
+            ParsedCredentialInner::JwtVcJsonLd(arc) => arc.id(),
+            ParsedCredentialInner::LdpVc(arc) => arc.id(),
+        }
+    }
+
+    /// Get the key alias for this credential.
+    pub fn key_alias(&self) -> Option<KeyAlias> {
+        match &self.inner {
+            ParsedCredentialInner::MsoMdoc(arc) => Some(arc.key_alias()),
+            ParsedCredentialInner::JwtVcJson(arc) => arc.key_alias(),
+            ParsedCredentialInner::JwtVcJsonLd(arc) => arc.key_alias(),
+            ParsedCredentialInner::LdpVc(arc) => arc.key_alias(),
+        }
+    }
+
     /// Return the credential as a JwtVc if it is of that format.
     pub fn as_jwt_vc(&self) -> Option<Arc<JwtVc>> {
         match &self.inner {


### PR DESCRIPTION
Add a couple of functions that make it easier to use ParsedCredential on the Swift/Kotlin side.