### PR TITLE
rename sd_jwt to vcdm2_sd_jwt

### DIFF
--- a/src/credential/vcdm2_sd_jwt.rs
+++ b/src/credential/vcdm2_sd_jwt.rs
@@ -16,7 +16,7 @@ use uniffi::deps::log;
 use uuid::Uuid;
 
 #[derive(Debug, uniffi::Object)]
-pub struct SdJwt {
+pub struct VCDM2SdJwt {
     pub(crate) id: Uuid,
     pub(crate) key_alias: Option<KeyAlias>,
     pub(crate) credential: JsonCredential,
@@ -24,7 +24,7 @@ pub struct SdJwt {
 }
 
 // Internal utility methods for decoding a SdJwt.
-impl SdJwt {
+impl VCDM2SdJwt {
     /// Return the revealed claims as a JSON value.
     pub fn revealed_claims_as_json(&self) -> Result<serde_json::Value, SdJwtError> {
         serde_json::to_value(&self.credential)
@@ -96,14 +96,14 @@ impl SdJwt {
 }
 
 #[uniffi::export]
-impl SdJwt {
+impl VCDM2SdJwt {
     /// Create a new SdJwt instance from a compact SD-JWS string.
     #[uniffi::constructor]
     pub fn new_from_compact_sd_jwt(input: String) -> Result<Arc<Self>, SdJwtError> {
         let inner: SdJwtBuf =
             SdJwtBuf::new(input).map_err(|e| SdJwtError::InvalidSdJwt(format!("{e:?}")))?;
 
-        let mut sd_jwt = SdJwt::try_from(inner)?;
+        let mut sd_jwt = VCDM2SdJwt::try_from(inner)?;
         sd_jwt.key_alias = None;
 
         Ok(Arc::new(sd_jwt))
@@ -118,7 +118,7 @@ impl SdJwt {
         let inner: SdJwtBuf =
             SdJwtBuf::new(input).map_err(|e| SdJwtError::InvalidSdJwt(format!("{e:?}")))?;
 
-        let mut sd_jwt = SdJwt::try_from(inner)?;
+        let mut sd_jwt = VCDM2SdJwt::try_from(inner)?;
         sd_jwt.key_alias = Some(key_alias);
 
         Ok(Arc::new(sd_jwt))
@@ -147,42 +147,42 @@ impl SdJwt {
     }
 }
 
-impl From<SdJwt> for ParsedCredential {
-    fn from(value: SdJwt) -> Self {
+impl From<VCDM2SdJwt> for ParsedCredential {
+    fn from(value: VCDM2SdJwt) -> Self {
         ParsedCredential {
-            inner: ParsedCredentialInner::SdJwt(Arc::new(value)),
+            inner: ParsedCredentialInner::VCDM2SdJwt(Arc::new(value)),
         }
     }
 }
 
-impl TryFrom<SdJwt> for Credential {
+impl TryFrom<VCDM2SdJwt> for Credential {
     type Error = SdJwtError;
 
-    fn try_from(value: SdJwt) -> Result<Self, Self::Error> {
+    fn try_from(value: VCDM2SdJwt) -> Result<Self, Self::Error> {
         ParsedCredential::from(value)
             .into_generic_form()
             .map_err(|e| SdJwtError::CredentialEncoding(format!("{e:?}")))
     }
 }
 
-impl TryFrom<Arc<SdJwt>> for Credential {
+impl TryFrom<Arc<VCDM2SdJwt>> for Credential {
     type Error = SdJwtError;
 
-    fn try_from(value: Arc<SdJwt>) -> Result<Self, Self::Error> {
+    fn try_from(value: Arc<VCDM2SdJwt>) -> Result<Self, Self::Error> {
         ParsedCredential::new_sd_jwt(value)
             .into_generic_form()
             .map_err(|e| SdJwtError::CredentialEncoding(format!("{e:?}")))
     }
 }
 
-impl TryFrom<&Credential> for SdJwt {
+impl TryFrom<&Credential> for VCDM2SdJwt {
     type Error = SdJwtError;
 
-    fn try_from(value: &Credential) -> Result<SdJwt, SdJwtError> {
+    fn try_from(value: &Credential) -> Result<VCDM2SdJwt, SdJwtError> {
         let inner = SdJwtBuf::new(value.payload.clone())
             .map_err(|_| SdJwtError::InvalidSdJwt(Default::default()))?;
 
-        let mut sd_jwt = SdJwt::try_from(inner)?;
+        let mut sd_jwt = VCDM2SdJwt::try_from(inner)?;
         // Set the ID and key alias from the credential.
         sd_jwt.id = value.id;
         sd_jwt.key_alias = value.key_alias.clone();
@@ -191,15 +191,15 @@ impl TryFrom<&Credential> for SdJwt {
     }
 }
 
-impl TryFrom<Credential> for Arc<SdJwt> {
+impl TryFrom<Credential> for Arc<VCDM2SdJwt> {
     type Error = SdJwtError;
 
-    fn try_from(value: Credential) -> Result<Arc<SdJwt>, SdJwtError> {
-        Ok(Arc::new(SdJwt::try_from(&value)?))
+    fn try_from(value: Credential) -> Result<Arc<VCDM2SdJwt>, SdJwtError> {
+        Ok(Arc::new(VCDM2SdJwt::try_from(&value)?))
     }
 }
 
-impl TryFrom<SdJwtBuf> for SdJwt {
+impl TryFrom<SdJwtBuf> for VCDM2SdJwt {
     type Error = SdJwtError;
 
     fn try_from(value: SdJwtBuf) -> Result<Self, Self::Error> {
@@ -208,7 +208,7 @@ impl TryFrom<SdJwtBuf> for SdJwt {
             .into_claims()
             .private;
 
-        Ok(SdJwt {
+        Ok(VCDM2SdJwt {
             id: Uuid::new_v4(),
             key_alias: None,
             inner: value,
@@ -318,7 +318,7 @@ pub(crate) mod tests {
     async fn test_sd_jwt() -> Result<(), SdJwtError> {
         let input = generate_sd_jwt().await;
 
-        assert!(SdJwt::new_from_compact_sd_jwt(input.to_string()).is_ok());
+        assert!(VCDM2SdJwt::new_from_compact_sd_jwt(input.to_string()).is_ok());
 
         Ok(())
     }

--- a/src/oid4vp/holder.rs
+++ b/src/oid4vp/holder.rs
@@ -270,7 +270,7 @@ impl Holder {
         credential: &Arc<ParsedCredential>,
     ) -> Result<VpToken, OID4VPError> {
         match &credential.inner {
-            ParsedCredentialInner::SdJwt(sd_jwt) => {
+            ParsedCredentialInner::VCDM2SdJwt(sd_jwt) => {
                 // TODO: need to provide the "filtered" (disclosed) fields of the
                 // credential to be encoded into the VpToken.
                 //
@@ -328,8 +328,7 @@ impl OID4VPWallet for Holder {
 #[cfg(test)]
 mod tests {
     use super::*;
-    // use crate::openid4vp::request_signer::ExampleRequestSigner;
-    use sd_jwt::SdJwt;
+    use vcdm2_sd_jwt::VCDM2SdJwt;
 
     // NOTE: This test requires the `companion` service to be running and
     // available at localhost:3000.
@@ -339,7 +338,7 @@ mod tests {
     #[tokio::test]
     async fn test_oid4vp_url() -> Result<(), Box<dyn std::error::Error>> {
         let example_sd_jwt = include_str!("../../tests/examples/sd_vc.jwt");
-        let sd_jwt = SdJwt::new_from_compact_sd_jwt(example_sd_jwt.into())?;
+        let sd_jwt = VCDM2SdJwt::new_from_compact_sd_jwt(example_sd_jwt.into())?;
         let credential = ParsedCredential::new_sd_jwt(sd_jwt);
 
         let initiate_api = "http://localhost:3000/api/oid4vp/initiate";


### PR DESCRIPTION
NOTE: We may wish to code freeze #43 for mobile development until end of the week. This PR makes name changes that will affect mobile codebases (CC @Juliano1612 @Joey-Silberman).

This PR is opened in reference to a comment in #43 (https://github.com/spruceid/mobile-sdk-rs/pull/43#discussion_r1809234489).